### PR TITLE
feat/td-32240 code review and quality improvement

### DIFF
--- a/benchmark/ob.c
+++ b/benchmark/ob.c
@@ -803,9 +803,11 @@ static int run_insert_with_param_binds(handles_t *handles, param_binds_t *param_
 {
   int r = 0;
 
-  size_t          nr_rows  = 0;
-  size_t          nr_batch = 0;
-  const char     *sql     = NULL;
+  size_t          nr_rows   = 0;
+  size_t          nr_batch  = 0;
+  const char     *sql       = NULL;
+  char           *endptr    = NULL;
+  long long       num       = 0;
 
   for (; i<argc; ++i) {
     const char *arg = argv[i];
@@ -816,7 +818,15 @@ static int run_insert_with_param_binds(handles_t *handles, param_binds_t *param_
         DUMP("<rows> is expected after --rows");
         return -1;
       }
-      nr_rows = (size_t)strtoll(argv[i], NULL, 0); // TODO: error check
+
+      errno = 0;
+      num = strtoll(argv[i], &endptr, 0);
+      if (endptr == argv[i] || *endptr != '\0' || errno != 0) {
+        DUMP("error: invalid rows number '%s'", argv[i]);
+        return -1;
+      }
+
+      nr_rows = (size_t)num;
       continue;
     }
     if (0 == strcasecmp(arg, "--batch")) {
@@ -824,7 +834,15 @@ static int run_insert_with_param_binds(handles_t *handles, param_binds_t *param_
         DUMP("<batch> is expected after --batch");
         return -1;
       }
-      nr_batch = (size_t)strtoll(argv[i], NULL, 0); // TODO: error check
+
+      errno = 0;
+      num = strtoll(argv[i], &endptr, 0);
+      if (endptr == argv[i] || *endptr != '\0' || errno != 0) {
+        DUMP("error: invalid batch number '%s'", argv[i]);
+        return -1;
+      }
+
+      nr_batch = (size_t)num;
       continue;
     }
     if (0 == strcasecmp(arg, "--sql")) {

--- a/benchmark/tb.c
+++ b/benchmark/tb.c
@@ -243,7 +243,21 @@ static int run(handles_t *handles, int argc, char *argv[])
         DUMP("<port> expected after --port");
         return -1;
       }
-      port = (uint16_t)strtoll(argv[++i], NULL, 0); // TODO: error check
+      char *endptr;
+      long long port_ll;
+      errno = 0;
+      port_ll = strtoll(argv[++i], &endptr, 0);
+      if (endptr == argv[i] || *endptr != '\0' || errno != 0) {
+        DUMP("error: invalid port number '%s'", argv[i]);
+        return -1;
+      }
+
+      if (port_ll < 0 || port_ll > UINT16_MAX) {
+        DUMP("error: port number out of range. must be between 0 and %u", UINT16_MAX);
+        return -1;
+      }
+
+      port = (uint16_t)port_ll;
       changed = 1;
       continue;
     }

--- a/inc/taos_helpers.h
+++ b/inc/taos_helpers.h
@@ -77,7 +77,6 @@ static inline setConfRet call_taos_set_config(const char *file, int line, const 
 {
   LOGD_TAOS(file, line, func, "taos_set_config(config:%s) ...", config);
   setConfRet r = taos_set_config(config);
-  // FIXME: how to dump errno/errmsg?
   LOGD_TAOS(file, line, func, "taos_set_config(config:%s) => (%d,%.*s)", config, r.retCode, (int)sizeof(r.retMsg), r.retMsg);
   return r;
 }

--- a/inc/taos_helpers.h
+++ b/inc/taos_helpers.h
@@ -200,14 +200,10 @@ static inline int call_taos_stmt_get_col_fields(const char *file, int line, cons
   return r;
 }
 
-EXTERN_C_BEGIN
-void bridge_taos_stmt_reclaim_fields(TAOS_STMT *stmt, TAOS_FIELD_E *fields) FA_HIDDEN;
-EXTERN_C_END
-
 static inline void call_taos_stmt_reclaim_fields(const char *file, int line, const char *func, TAOS_STMT *stmt, TAOS_FIELD_E *fields)
 {
   LOGD_TAOS(file, line, func, "taos_stmt_reclaim_fields(stmt:%p,fields:%p) ...", stmt, fields);
-  bridge_taos_stmt_reclaim_fields(stmt, fields);
+  taos_stmt_reclaim_fields(stmt, fields);
   LOGD_TAOS(file, line, func, "taos_stmt_reclaim_fields(stmt:%p,fields:%p) => void", stmt, fields);
 }
 

--- a/inc/taosws_helpers.h
+++ b/inc/taosws_helpers.h
@@ -93,6 +93,14 @@ static inline const char *call_ws_get_server_info(const char *file, int line, co
   return s;
 }
 
+static inline const char *call_ws_get_client_info(const char *file, int line, const char *func)
+{
+  LOGD_TAOSWS(file, line, func, "ws_get_server_info() ...");
+  const char *s = ws_get_client_info();
+  LOGD_TAOSWS(file, line, func, "ws_get_server_info() => %s", s);
+  return s;
+}
+
 static inline int call_ws_close(const char *file, int line, const char *func, WS_TAOS *taos)
 {
   LOGD_TAOSWS(file, line, func, "ws_close(ws_taos:%p) ...", taos);
@@ -354,6 +362,7 @@ static inline int32_t call_ws_stmt_close(const char *file, int line, const char 
 #define CALL_ws_enable_log(...)                          call_ws_enable_log(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define CALL_ws_connect(...)                             call_ws_connect(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define CALL_ws_get_server_info(...)                     call_ws_get_server_info(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
+#define CALL_ws_get_client_info(...)                     call_ws_get_client_info(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define CALL_ws_close(...)                               call_ws_close(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define CALL_ws_query(...)                               call_ws_query(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define CALL_ws_stop_query(...)                          call_ws_stop_query(__FILE__, __LINE__, __func__, ##__VA_ARGS__)

--- a/src/core/desc.c
+++ b/src/core/desc.c
@@ -274,6 +274,14 @@ SQLRETURN descriptor_bind_col(descriptor_t *ARD,
       ARD_record->DESC_CONCISE_TYPE      = TargetType;
       ARD_record->DESC_OCTET_LENGTH      = BufferLength;
       break;
+    case SQL_C_BINARY:
+      ARD_record->DESC_LENGTH            = 0; // FIXME:
+      ARD_record->DESC_PRECISION         = 0;
+      ARD_record->DESC_SCALE             = 0;
+      ARD_record->DESC_TYPE              = TargetType;
+      ARD_record->DESC_CONCISE_TYPE      = TargetType;
+      ARD_record->DESC_OCTET_LENGTH      = BufferLength;
+      break;
     default:
       stmt_append_err_format(owner, "HY000", 0,
           "General error:#%d Column converstion to `%s[0x%x/%d]` not implemented yet",

--- a/src/core/ds.c
+++ b/src/core/ds.c
@@ -63,8 +63,7 @@ static const char* _ds_ws_get_client_info(ds_conn_t *ds_conn)
 {
   OA_NIY(ds_conn->conn);
 
-  // FIXME:
-  return "client_info-undefined-under-taosws-for-the-moment";
+  return CALL_ws_get_client_info();
 }
 
 static int _ds_ws_get_current_db_with_ds_res(ds_conn_t *ds_conn, char *db, size_t len, ds_res_t *ds_res, ds_err_t *ds_err)
@@ -202,7 +201,7 @@ static int _ds_tsdb_get_current_db(ds_conn_t *ds_conn, char *db, size_t len, ds_
 
   OA_NIY(ds_conn->conn);
 
-  int required = 0; // FIXME: what usage?
+  int required = 0;
   r = CALL_taos_get_current_db((TAOS*)ds_conn->taos, db, (int)len, &required);
   if (r) {
     ds_err->err = taos_errno(NULL);

--- a/src/core/internal.h
+++ b/src/core/internal.h
@@ -806,7 +806,7 @@ struct tables_args_s {
   wildex_t        *schema_pattern;
   wildex_t        *table_pattern;
   wildex_t        *type_pattern;
-  char             db[1024];  // FIXME: big enough? check [taosc]
+  char             db[1024];    // already big enough! see TSDB_DB_NAME_LEN(65) in tdef.h
   uint8_t          select_current_db:1;
 };
 

--- a/src/core/stmt.c
+++ b/src/core/stmt.c
@@ -4444,7 +4444,19 @@ static SQLRETURN _stmt_param_check_sqlc_double_sql_real(stmt_t *stmt, param_stat
   sql_data_t    *data       = &param_state->sql_data;
 
   double v = sqlc_data->dbl;
-  // TODO: check if 'Numeric value out of range'
+
+  if (v > FLT_MAX || v < -FLT_MAX) {
+    stmt_append_err_format(stmt, "HY000", 0,
+        "General error:conversion from `SQL_DOUBLE` to `SQL_FLOAT` failed,numeric value out of range for SQL_REAL,value:%lf", v);
+    return SQL_ERROR;
+  }
+
+  if ((v != 0) && (fabs(v) < FLT_MIN)) {
+    stmt_append_err_format(stmt, "HY000", 0,
+        "Warning: value too small for SQL_REAL, will be rounded to 0,value:%lf", v);
+    v = 0.0;
+  }
+
   data->flt  = (float)v;
   data->type = SQL_REAL;
 

--- a/src/core/tsdb.c
+++ b/src/core/tsdb.c
@@ -168,7 +168,8 @@ static void _tsdb_params_reset_tag_fields(tsdb_params_t *params)
   if (params->tag_fields) {
 #ifdef HAVE_TAOSWS           /* [ */
     if (params->owner->owner->conn->cfg.url) {
-      OA_NIY(params->tag_fields == NULL);
+      // OA_NIY(params->tag_fields == NULL);
+      CALL_ws_stmt_reclaim_fields(params->owner->stmt, (struct StmtField**)&params->tag_fields, params->nr_tag_fields);
     } else {
 #endif                       /* ] */
       CALL_taos_stmt_reclaim_fields(params->owner->stmt, params->tag_fields);
@@ -698,6 +699,8 @@ static SQLRETURN _tsdb_stmt_get_taos_tags_cols_for_insert(tsdb_stmt_t *stmt)
       OA_NIY(stmt->params.nr_tag_fields == 0);
       stmt->params.tag_fields = tag_fields;
       stmt->params.nr_tag_fields = tagNum;
+      // TODO: temp modify
+      // if (tagNum == 0) stmt->params.tag_fields = NULL;
       sr = _tsdb_stmt_describe_cols(stmt);
     }
   } else {

--- a/src/tests/basic.c
+++ b/src/tests/basic.c
@@ -1873,7 +1873,6 @@ static int run(const char *test_case)
 int main(int argc, char *argv[])
 {
   int r = 0;
-
   int tested = 0;
 
   for (int i=1; i<argc; ++i) {
@@ -1887,7 +1886,15 @@ int main(int argc, char *argv[])
         return 1;
       }
       ++i;
-      long long times = strtoll(argv[i], NULL, 0); // FIXME: error check
+
+      errno = 0;
+      char *endptr;
+      long long times = strtoll(argv[i], &endptr, 0);
+      if (endptr == argv[i] || *endptr != '\0' || errno != 0) {
+        fprintf(stderr, "error: invalid times number '%s'\n", argv[i]);
+        return 1;
+      }
+
       if (times > 0 && (size_t)times > iconv_case.times) {
         iconv_case.times = (size_t)times;
       }


### PR DESCRIPTION
1. Remove the bridge function for taos_stmt_reclaim_fields, which is already provided on all platforms;
2. Add the parsing of valbinary/geometry data in WebSocket and add corresponding test cases;
3. SQLBindCol interface supports binary type.
4. Troubleshoot resource leaks in tag fields.