### PR TITLE
fix/TD-33553: fix bug when SQLSetConnectAttr set property SQL_ATTR_TXN_ISOLATION

### DIFF
--- a/src/core/conn.c
+++ b/src/core/conn.c
@@ -1811,7 +1811,7 @@ SQLRETURN conn_set_attr(
     case SQL_ATTR_TRANSLATE_OPTION:
       break;
     case SQL_ATTR_TXN_ISOLATION:
-      conn->txn_isolation = *(int32_t*)ValuePtr;
+      conn->txn_isolation = (SQLINTEGER)(SQLLEN)ValuePtr;
       return SQL_SUCCESS;
     case SQL_ATTR_MAX_ROWS:
       if ((SQLULEN)ValuePtr == 0) return SQL_SUCCESS;

--- a/tests/cpp/SQLBindCol_ref.cpp
+++ b/tests/cpp/SQLBindCol_ref.cpp
@@ -93,6 +93,9 @@ static int test_case1(const char *conn_str, int ws)
       rc = CALL_SQLSetConnectAttr(hdbc, SQL_LOGIN_TIMEOUT, (SQLPOINTER)5, 0);
       A(SUCCEEDED(rc), "");
 
+      rc = CALL_SQLSetConnectAttr(hdbc, SQL_ATTR_TXN_ISOLATION, (SQLPOINTER)SQL_TXN_SERIALIZABLE, 0);
+      A(SUCCEEDED(rc), "");
+
       // Connect to data source
       rc = CALL_SQLDriverConnect(hdbc, NULL,
             (SQLCHAR*)conn_str, SQL_NTS,


### PR DESCRIPTION
When setting connection attributes, the value of attribute type SQL_ATTR_TXN_ISOLATION does not conform to the standard, and the value is incorrectly treated as a pointer, causing core